### PR TITLE
Trie::load should test keyNum_ same as Trie::build

### DIFF
--- a/src/uxTest.cpp
+++ b/src/uxTest.cpp
@@ -35,6 +35,23 @@ TEST(ux, trivial){
   ASSERT_EQ(ux::NOTFOUND, ux.prefixSearch(q.c_str(), q.size(), retLen));
 }
 
+TEST(ux, empty_save_load) {
+  ux::Trie ux;
+  vector<string> wordList;
+  ux.build(wordList);
+
+  {
+    std::stringstream ss;
+    ux.save(ss);
+    ss.seekg(0);
+    ux.load(ss);
+  }
+
+  string q = "hoge";
+  size_t retLen = 0;
+  ASSERT_EQ(ux::NOTFOUND, ux.prefixSearch(q.c_str(), q.size(), retLen));
+}
+
 TEST(ux, simple){
   vector<string> wordList;
   wordList.push_back("i");

--- a/src/uxTrie.cpp
+++ b/src/uxTrie.cpp
@@ -232,7 +232,9 @@ int Trie::load(std::istream& is){
   if (!is){
     return LOAD_ERROR;
   }
-  isReady_ = true;
+  if (keyNum_ > 0){
+    isReady_ = true;
+  }
   return 0;
 }
   


### PR DESCRIPTION
Same as `Trie::build`, `Trie::load` should check `keyNum_` to say "I'm ready".